### PR TITLE
[WIP] Working on Oculus remote support

### DIFF
--- a/demo/Main.tscn
+++ b/demo/Main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=12 format=2]
+[gd_scene load_steps=13 format=2]
 
 [ext_resource path="res://Main.gd" type="Script" id=1]
 [ext_resource path="res://Milkyway.png" type="Texture" id=2]
@@ -6,6 +6,7 @@
 [ext_resource path="res://addons/godot-oculus/scenes/oculus_first_person.tscn" type="PackedScene" id=4]
 [ext_resource path="res://addons/vr-common/functions/Function_Teleport.tscn" type="PackedScene" id=5]
 [ext_resource path="res://addons/vr-common/functions/Function_Direct_movement.tscn" type="PackedScene" id=6]
+[ext_resource path="res://Oculus_remote.gd" type="Script" id=7]
 
 [sub_resource type="PanoramaSky" id=1]
 
@@ -103,6 +104,7 @@ flags_use_point_size = false
 flags_world_triplanar = false
 flags_fixed_size = false
 flags_albedo_tex_force_srgb = false
+flags_do_not_receive_shadows = false
 vertex_color_use_as_albedo = false
 vertex_color_is_srgb = false
 params_diffuse_mode = 1
@@ -147,6 +149,8 @@ _sections_unfolded = [ "Albedo" ]
 [sub_resource type="PlaneMesh" id=4]
 
 material = SubResource( 3 )
+custom_aabb = AABB( 0, 0, 0, 0, 0, 0 )
+flip_faces = false
 size = Vector2( 10, 10 )
 subdivide_width = 10
 subdivide_depth = 10
@@ -156,15 +160,12 @@ subdivide_depth = 10
 plane = Plane( 0, 1, 0, 0 )
 
 [node name="Main" type="Spatial" index="0"]
-
 script = ExtResource( 1 )
 
 [node name="WorldEnvironment" type="WorldEnvironment" parent="." index="0"]
-
 environment = SubResource( 2 )
 
 [node name="DirectionalLight" type="DirectionalLight" parent="." index="1"]
-
 transform = Transform( 0.623013, -0.733525, 0.271654, 0.321394, 0.55667, 0.766044, -0.713134, -0.389948, 0.582563, 0, 100, 0 )
 layers = 1
 light_color = Color( 1, 1, 1, 1 )
@@ -192,7 +193,6 @@ directional_shadow_max_distance = 200.0
 _sections_unfolded = [ "Transform" ]
 
 [node name="Ground" type="StaticBody" parent="." index="2"]
-
 input_ray_pickable = true
 input_capture_on_drag = false
 collision_layer = 1
@@ -203,7 +203,6 @@ constant_linear_velocity = Vector3( 0, 0, 0 )
 constant_angular_velocity = Vector3( 0, 0, 0 )
 
 [node name="Ground" type="MeshInstance" parent="Ground" index="0"]
-
 transform = Transform( 100, 0, 0, 0, 100, 0, 0, 0, 100, 0, 0, 0 )
 layers = 1
 material_override = null
@@ -220,14 +219,12 @@ material/0 = null
 _sections_unfolded = [ "Transform" ]
 
 [node name="CollisionShape" type="CollisionShape" parent="Ground" index="1"]
-
 shape = SubResource( 5 )
 disabled = false
 
 [node name="Table" parent="." index="3" instance=ExtResource( 3 )]
 
 [node name="Test" type="MeshInstance" parent="." index="4"]
-
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.63647, -1.15364 )
 layers = 1
 material_override = null
@@ -244,13 +241,17 @@ skeleton = NodePath("..")
 [node name="FirstPerson" parent="." index="5" instance=ExtResource( 4 )]
 
 [node name="Function_Teleport" parent="FirstPerson/Left_Hand" index="1" instance=ExtResource( 5 )]
-
 origin = NodePath("../..")
 
 [node name="Function_Direct_movement" parent="FirstPerson/Right_Hand" index="1" instance=ExtResource( 6 )]
-
 origin = NodePath("../..")
 camera = NodePath("../../ARVRCamera")
 
+[node name="Oculus_remote" type="ARVRController" parent="FirstPerson" index="4"]
+controller_id = 3
+rumble = 0.0
+script = ExtResource( 7 )
+
+[connection signal="button_pressed" from="FirstPerson/Oculus_remote" to="FirstPerson/Oculus_remote" method="_on_Oculus_remote_button_pressed"]
 
 [editable path="FirstPerson"]

--- a/demo/Oculus_remote.gd
+++ b/demo/Oculus_remote.gd
@@ -1,0 +1,5 @@
+extends ARVRController
+
+func _on_Oculus_remote_button_pressed(button):
+	# just testing for now
+	print("Button " + str(button) + " pressed on the oculus remote")

--- a/src/ARVRInterface.h
+++ b/src/ARVRInterface.h
@@ -40,6 +40,7 @@ extern const godot_arvr_interface_gdnative interface_struct;
 enum trackers {
 	TRACKER_LEFT_TOUCH,
 	TRACKER_RIGHT_TOUCH,
+	TRACKER_OCULUS_REMOTE,
 	MAX_TRACKERS
 };
 


### PR DESCRIPTION
This mostly works. I'm representing it as an ARVR controller even though it is not tracked but we don't have a pure joystick API in GDNative yet.

Directional buttons are working and mapped to JOY_DPAD_UP/DOWN/LEFT/RIGHT

Selection and back buttons don't work for some reason, I'm not sure why yet. They also overlap with A/B on the touch controllers, weird design choice on Oculus' part.