### PR TITLE
Tweaking some settings to get the cups to behave nicely

### DIFF
--- a/demo/Main.tscn
+++ b/demo/Main.tscn
@@ -24,6 +24,7 @@ shadow_bias = 0.01
 directional_shadow_normal_bias = 0.1
 
 [node name="FirstPerson" parent="." instance=ExtResource( 4 )]
+physics_factor = 2.0
 
 [node name="vr_common_shader_cache" parent="FirstPerson/ARVRCamera" index="0" instance=ExtResource( 5 )]
 

--- a/demo/addons/godot-oculus/scenes/oculus_first_person.gd
+++ b/demo/addons/godot-oculus/scenes/oculus_first_person.gd
@@ -1,5 +1,7 @@
 extends ARVROrigin
 
+export var physics_factor = 2.0
+
 var oculus_config = null;
 var refresh_rate = 0;
 
@@ -27,7 +29,7 @@ func _process(delta):
 		refresh_rate = round(oculus_config.get_refresh_rate())
 		
 		if refresh_rate != 0:
-			print("Setting physics rate to " + str(refresh_rate))
+			print("Setting physics rate to " + str(refresh_rate * physics_factor))
 		
-			# up our physics to 90fps to get in sync with our rendering
-			Engine.iterations_per_second = refresh_rate
+			# set our physics in sync with our rendering
+			Engine.iterations_per_second = refresh_rate * physics_factor

--- a/demo/objects/Cup.gd
+++ b/demo/objects/Cup.gd
@@ -2,10 +2,32 @@ extends "res://addons/godot-xr-tools/objects/Object_pickable.gd"
 
 var material : SpatialMaterial
 
+onready var original_transform = global_transform
+var max_distance = 5.0
+
 func _ready():
 	material = $Cup.material
 	material.emission_enabled = false
+	
+	# we can programatically set our margin smaller which is important with small objects like a cup
+	$CollisionShape.shape.margin = 0.0001
 
 func _update_highlight():
 	if material:
 		material.emission_enabled = closest_count > 0
+
+func _physics_process(delta):
+	if !is_picked_up():
+		var delta_pos = global_transform.origin - original_transform.origin
+		if delta_pos.length() > max_distance:
+			# We've rolled away
+			
+			# Arresto Momentum!
+			linear_velocity = Vector3.ZERO
+			angular_velocity = Vector3.ZERO
+			
+			# Let's put it back but a little higher
+			global_transform = original_transform
+			global_transform.origin.y += 0.5 
+			pass
+			

--- a/demo/objects/Cup.tscn
+++ b/demo/objects/Cup.tscn
@@ -3,8 +3,10 @@
 [ext_resource path="res://addons/godot-xr-tools/objects/Object_pickable.tscn" type="PackedScene" id=1]
 [ext_resource path="res://objects/Cup.gd" type="Script" id=2]
 
-[sub_resource type="BoxShape" id=3]
-extents = Vector3( 0.05, 0.05, 0.05 )
+[sub_resource type="CylinderShape" id=1]
+margin = 0.01
+radius = 0.05
+height = 0.1
 
 [sub_resource type="SpatialMaterial" id=2]
 resource_local_to_scene = true
@@ -22,11 +24,12 @@ collision_layer = 4
 collision_mask = 1022
 mass = 0.1
 continuous_cd = true
+can_sleep = false
 script = ExtResource( 2 )
 reset_transform_on_pickup = false
 
 [node name="CollisionShape" parent="." index="0"]
-shape = SubResource( 3 )
+shape = SubResource( 1 )
 
 [node name="Cup" type="CSGCylinder" parent="." index="1"]
 radius = 0.05


### PR DESCRIPTION
I had set cube collision shapes on the cups to work around issues with the cylinder shapes. After getting some feedback experimented with changing settings.

First, you can't set the margin below 0.01 in the IDE. That is 1cm for a cup that is 10 cm high. Way to much. 
But you can change it programmatically so I've set it to 0.001. 

The problem we now get is that bullet has great problems handling this properly unless you up the physics update rate. They recommend going as high as 300 updates per second. 

Because we want the physics update rate to be in sync with the headset update rate I've added a factor to our init script that defaults setting the update rate to 2x the headset rate (160 updates per second on a Rift S). That already makes the simulation of our cups pretty stable.
Going higher works even better. 